### PR TITLE
Fixed initialization of the "secure" option

### DIFF
--- a/cookies.js
+++ b/cookies.js
@@ -36,7 +36,7 @@
             path: options && options.path || Cookies.defaults.path,
             domain: options && options.domain || Cookies.defaults.domain,
             expires: options && options.expires || Cookies.defaults.expires,
-            secure: options && options.secure || Cookies.defaults.secure
+            secure: (options && typeof options.secure !== undefined) ? o.secure : Cookies.defaults.secure
         };
         
         switch (typeof options.expires) {


### PR DESCRIPTION
When the `option.secure` is set to `false`, the check `options && options.secure || Cookies.defaults.secure` returns the default value instead of `false`
