### PR TITLE
avoid pass native function to string.replace

### DIFF
--- a/src/cookies.js
+++ b/src/cookies.js
@@ -70,9 +70,9 @@
     };
 
     Cookies._generateCookieString = function (key, value, options) {
-        key = key.replace(/[^#$&+\^`|]/g, encodeURIComponent);
+        key = key.replace(/[^#$&+\^`|]/g, function(s) { return encodeURIComponent(s) });
         key = key.replace(/\(/g, '%28').replace(/\)/g, '%29');
-        value = (value + '').replace(/[^!#$&-+\--:<-\[\]-~]/g, encodeURIComponent);
+        value = (value + '').replace(/[^!#$&-+\--:<-\[\]-~]/g, function(s) { return encodeURIComponent(s) });
         options = options || {};
 
         var cookieString = key + '=' + value;


### PR DESCRIPTION
I use the cookies-js in a STB project. It contains an old and quirky browser(called ipanel).

If use string.replace and pass native function, it will like this:

``` javascript
var a = "12345".replace(/4/, encodeURIComponent);
alert(a); // print 123encodeURIComponent(){ [native code]}5
```

It must wrap the native function.

``` javascript
var a = "12345".replace(/4/,function(s) { return encodeURIComponent(s) });
alert(a); // print 12345
```
