### PR TITLE
Add "files" to "package.json"

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,5 +10,6 @@
         "type": "git",
         "url": "git://github.com/ScottHamper/Cookies.git"
     },
-    "main"          : "./dist/cookies.js"
+    "main"          : "./dist/cookies.js",
+    "files"         : ["dist/*", "src/*", "CHANGELOG.md", "README.md", "UNLICENSE"]
 }


### PR DESCRIPTION
Specify what files to include in npm releases - this way `tests` and `bower.json` don't get included in the packaged version. (See https://docs.npmjs.com/files/package.json#files)