### PR TITLE
Add the package name which is published in npm for TypeScript's defenition file.

### DIFF
--- a/src/cookies.d.ts
+++ b/src/cookies.d.ts
@@ -27,3 +27,7 @@ declare var Cookies:CookiesStatic;
 declare module "cookies" {
     export = Cookies;
 }
+
+declare module "cookies-js" {
+    export = Cookies;
+}


### PR DESCRIPTION
This fix #45.

The root problem of #45 is that the module name is different between TypeScript's module name and npm published name. Thus this patch adds an another module name definition which is same as npm published package name.