### PR TITLE
Stop breaking isomorphic apps

### DIFF
--- a/src/cookies.js
+++ b/src/cookies.js
@@ -153,8 +153,7 @@
 
         return Cookies;
     };
-
-    var cookiesExport = typeof global.document === 'object' ? factory(global) : factory;
+    var cookiesExport = (global && typeof global.document === 'object') ? factory(global) : factory;
 
     // AMD support
     if (typeof define === 'function' && define.amd) {


### PR DESCRIPTION
When using webpack `this` is undefined, and window is undefined on the server. This breaks isomorphic apps. All that needs to be done is to check to see if global is falsy.

I don't know how you make your dist files, so I didn't do any of that.