### PR TITLE
Support "Same-Site" cookies

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,8 @@ Sets a cookie in the document. If the cookie does not already exist, it will be 
 |  *domain* | A string value of the domain of the cookie                                                       | `undefined` |
 | *expires* | A number (of seconds), a date parsable string, or a `Date` object of when the cookie will expire | `undefined` |
 |  *secure* | A boolean value of whether or not the cookie should only be available over SSL                   | `false`     |
+|  *sameSite* | <p>Use "SameSite" cookie attribute?</p><p>Value is one of: </p><ul><li>`undefined`: don't use "SameSite".</li><li>`"strict"`: use "SameSite" with value `"Strict"`.</li><li>`"Strict"`: use "SameSite" with value `"Strict"`.</li><li>`"lax"`: use "SameSite" with value `"Lax"`.</li><li>`"Lax"`: use "SameSite" with value `"Lax"`.</li> | `undefined` |
+
 
 A default value for any option may be set in the `Cookies.defaults` object.
 
@@ -109,6 +111,14 @@ Cookies.set('key', 'value', { expires: 600 }); // Expires in 10 minutes
 Cookies.set('key', 'value', { expires: '01/01/2012' });
 Cookies.set('key', 'value', { expires: new Date(2012, 0, 1) });
 Cookies.set('key', 'value', { expires: Infinity });
+
+// Setting cookies with "SameSite" attribute
+Cookies.set('key', 'value'); // Don't use "SameSite"
+Cookies.set('key', 'value', { sameSite: undefined }); // Don't use "SameSite"
+Cookies.set('key', 'value', { sameSite: 'strict' }); // Use "SameSite" with value "Strict"
+Cookies.set('key', 'value', { sameSite: 'Strict' }); // Use "SameSite" with value "Strict"
+Cookies.set('key', 'value', { sameSite: 'lax' }); // Use "SameSite" with value "Lax"
+Cookies.set('key', 'value', { sameSite: 'Lax' }); // Use "SameSite" with value "Lax"
 
 // Using the alias
 Cookies('key', 'value', { secure: true });
@@ -177,6 +187,7 @@ An object representing default options to be used when setting and expiring cook
 |  *domain* | A string value of the domain of the cookie                                                       | `undefined` |
 | *expires* | A number (of seconds), a date parsable string, or a `Date` object of when the cookie will expire | `undefined` |
 |  *secure* | A boolean value of whether or not the cookie should only be available over SSL                   | `false`     |
+|  *sameSite* | <p>Use "SameSite" cookie attribute?</p><p>Value is one of: </p><ul><li>`undefined`: don't use "SameSite".</li><li>`"strict"`: use "SameSite" with value `"Strict"`.</li><li>`"Strict"`: use "SameSite" with value `"Strict"`.</li><li>`"lax"`: use "SameSite" with value `"Lax"`.</li><li>`"Lax"`: use "SameSite" with value `"Lax"`.</li> | `undefined` |
 
 **Example Usage**
 ```javascript

--- a/src/cookies.js
+++ b/src/cookies.js
@@ -28,7 +28,8 @@
 
         Cookies.defaults = {
             path: '/',
-            secure: false
+            secure: false,
+            sameSite: undefined
         };
 
         Cookies.get = function (key) {
@@ -59,7 +60,8 @@
                 path: options && options.path || Cookies.defaults.path,
                 domain: options && options.domain || Cookies.defaults.domain,
                 expires: options && options.expires || Cookies.defaults.expires,
-                secure: options && options.secure !== undefined ?  options.secure : Cookies.defaults.secure
+                secure: options && options.secure !== undefined ?  options.secure : Cookies.defaults.secure,
+                sameSite: options && options.sameSite || Cookies.defaults.sameSite
             };
         };
 
@@ -84,6 +86,22 @@
             return expires;
         };
 
+        Cookies._generateSameSiteString = function (options) {
+            var sameSite = options && options.sameSite || Cookies.defaults.sameSite;
+            switch (sameSite) {
+                case undefined:
+                    return '';
+                case 'Lax':
+                case 'lax':
+                    return ';sameSite=Lax';
+                case 'Strict':
+                case 'strict':
+                    return ';sameSite=Strict';
+                default:
+                    throw new TypeError(sameSite + ' is not valid value for option "sameSite"'); 
+            }
+        }
+
         Cookies._generateCookieString = function (key, value, options) {
             key = key.replace(/[^#$&+\^`|]/g, encodeURIComponent);
             key = key.replace(/\(/g, '%28').replace(/\)/g, '%29');
@@ -95,6 +113,7 @@
             cookieString += options.domain ? ';domain=' + options.domain : '';
             cookieString += options.expires ? ';expires=' + options.expires.toUTCString() : '';
             cookieString += options.secure ? ';secure' : '';
+            cookieString += Cookies._generateSameSiteString(options)
 
             return cookieString;
         };

--- a/tests/spec/cookies-spec.js
+++ b/tests/spec/cookies-spec.js
@@ -58,6 +58,10 @@ describe('UNIT TESTS', function () {
         it('has a defined `secure` value of `false`', function () {
             expect(Cookies.defaults.secure).toBe(false);
         });
+
+        it('has an undefined `sameSite` value', function () {
+            expect(Cookies.defaults.sameSite).toBeUndefined();
+        });
     });
 
     describe('Cookies.get(key)', function () {
@@ -434,6 +438,39 @@ describe('UNIT TESTS', function () {
                 var options = { secure: true };
                 expect(Cookies._generateCookieString(key, value, options)).toEqual('key=value;secure');
             });
+
+            it('does not include "same site" flag if `options.sameSite` is not defined', function () {
+                var options = { sameSite: undefined };
+                expect(Cookies._generateCookieString(key, value, options)).toEqual('key=value'); 
+            });
+
+            it('includes "same site" flag with value "Lax" if `options.sameSite` is "Lax"', function () {
+                var options = { sameSite: 'Lax' };
+                expect(Cookies._generateCookieString(key, value, options)).toEqual('key=value;sameSite=Lax'); 
+            });
+
+            it('includes "same site" flag with value "Lax" if `options.sameSite` is "lax"', function () {
+                var options = { sameSite: 'lax' };
+                expect(Cookies._generateCookieString(key, value, options)).toEqual('key=value;sameSite=Lax'); 
+            });
+
+            it('includes "same site" flag with value "Strict" if `options.sameSite` is "Strict"', function () {
+                var options = { sameSite: 'Strict' };
+                expect(Cookies._generateCookieString(key, value, options)).toEqual('key=value;sameSite=Strict'); 
+            });
+
+            it('includes "same site" flag with value "Strict" if `options.sameSite` is "strict"', function () {
+                var options = { sameSite: 'strict' };
+                expect(Cookies._generateCookieString(key, value, options)).toEqual('key=value;sameSite=Strict'); 
+            });
+
+            it(
+                'throws Error when `options.sameSite` is not undefined, "lax", "Lax", "strict", or "Strict"',
+                function () {
+                    var options = { sameSite: true };
+                    expect(function () { Cookies._generateCookieString(key, value, options); }).toThrow();
+                }
+            );
         });
         
         describe('Cookies._getCacheFromString(documentCookie)', function () {


### PR DESCRIPTION
This PR makes this library able to support "SameSite" attribute. "SameSite" attribute is used to prevent CSRF attack.

More about same-site cookies: http://www.sjoerdlangkemper.nl/2016/04/14/preventing-csrf-with-samesite-cookie-attribute/