### PR TITLE
Remove "cookies" module declaration

### DIFF
--- a/src/cookies.d.ts
+++ b/src/cookies.d.ts
@@ -24,10 +24,6 @@ interface CookiesStatic {
 
 declare var Cookies:CookiesStatic;
 
-declare module "cookies" {
-    export = Cookies;
-}
-
 declare module "cookies-js" {
     export = Cookies;
 }


### PR DESCRIPTION
There is a quite popular Node.js cookie library called [cookies](https://www.npmjs.com/package/cookies) on npm that – absolutely justified – declares a "cookies" TypeScript module.
This complicates things in isomorphic applications where both libraries are included. A very good example for this is [redux-persist-cookie-storage](https://github.com/abersager/redux-persist-cookie-storage) – I've seen people [ts-ignoring](https://medium.com/@HamidTanhaei/react-ssr-persist-redux-data-19cc2a667217) because of this :cry:

@ScottHamper I would be super-glad if you could have a quick look at this one! Thanks :)